### PR TITLE
Implement mirror ray intersection logic

### DIFF
--- a/src/raytracing/Mirror.ts
+++ b/src/raytracing/Mirror.ts
@@ -1,5 +1,6 @@
 import { ID, UniqueID } from "../UniqueID";
 import { Ray } from "./Ray";
+import { Point } from "../types";
 
 export abstract class Mirror {
   id: ID;
@@ -13,5 +14,11 @@ export abstract class Mirror {
    * If no intersection, it returns an empty array
    */
   abstract splitAndReflectSegment(ray: Ray): Ray[];
+  /**
+   * Computes the first intersection between this mirror and the provided ray.
+   * Returns the intersection point in world coordinates and the distance from the ray origin,
+   * or null if there is no intersection within both the mirror's bounds and the ray length.
+   */
+  abstract intersect(ray: Ray): { point: Point; distance: number } | null;
   abstract render(context: CanvasRenderingContext2D): void;
 }


### PR DESCRIPTION
Add `intersect` method to `Mirror` and its implementations to standardize ray intersection calculations.

This provides a unified API for determining ray-mirror intersections, returning the point and distance, and refactors `splitAndReflectSegment` to leverage this new logic, improving code reuse and clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d953705-46cc-4f3a-a408-8dcbde72ffc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d953705-46cc-4f3a-a408-8dcbde72ffc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

