### PR TITLE
Add ray intersection distance method to mirrors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,18 +28,43 @@ let t = 0;
 const tMax = 3;
 const tSpread = 0.05; // draw 1/20th on either side of the T point
 
-const emitter: Emitter = new LinearEmitter(
-  { x: 100, y: 200 },
-  { x: 100, y: 500 },
-  0,
-  50,
-  3000,
-  { start: 0, end: tMax },
-  "red",
-);
+const emitters: Emitter[] = [
+  new LinearEmitter(
+    { x: 100, y: 200 },
+    { x: 100, y: 500 },
+    0,
+    50,
+    3000,
+    { start: 0, end: tMax },
+    "red",
+  ), new LinearEmitter(
+    { x: 100, y: 195 },
+    { x: 100, y: 495 },
+    -0.01,
+    50,
+    3000,
+    { start: 0, end: tMax },
+    "green",
+  ), new LinearEmitter(
+    { x: 100, y: 205 },
+    { x: 100, y: 505 },
+    0.01,
+    50,
+    3000,
+    { start: 0, end: tMax },
+    "blue",
+  )
+];
 
 // Generate rays from emitters
-let rays: Ray[] = [...emitter.generateRays()];
+let rays: Ray[];
+
+const parabolicMirror = new ParabolicMirror({
+  vertex: { x: 1000, y: 350 },
+  focalLength: 700,
+  width: 300,
+  orientation: Direction.LEFT,
+});
 
 const mirrors: Mirror[] = [
   new FlatMirror({
@@ -47,17 +72,12 @@ const mirrors: Mirror[] = [
     normal: { dx: 1, dy: 1 },
     length: 200,
   }),
-  new ParabolicMirror({
-    vertex: { x: 1000, y: 350 },
-    focalLength: 700,
-    width: 300,
-    orientation: Direction.fromAngle(0),
-  }),
+  parabolicMirror
 ];
 
 // Function to recalculate rays when mirror orientation changes
 function recalculateRays() {
-  rays = [...emitter.generateRays()];
+  rays = emitters.flatMap(emitter => emitter.generateRays());
 
 	let anyBounced = true;
 	for (let i = 0; i < 10 && anyBounced; i++) {
@@ -108,7 +128,7 @@ const animationLoop = new AnimationLoop((deltaTimeMs: number) => {
   const canvasHeight = canvas.height / window.devicePixelRatio;
   grid.render(context, canvasWidth, canvasHeight);
 
-  emitter.render(context);
+  emitters.forEach(emitter => emitter.render(context));
 
   t += deltaTimeMs / 1000;
   if (t > tMax + tSpread) {
@@ -154,18 +174,17 @@ window.addEventListener("keydown", (event) => {
     animationLoop.stepBack();
   } else if (event.code === "ArrowLeft") {
     // Rotate mirror counterclockwise by 5 degrees
-    const mirror = mirrors[1] as ParabolicMirror;
-    const currentOrientation = mirror.orientation;
+    const currentOrientation = parabolicMirror.orientation;
     const newOrientation = currentOrientation - (5 * Math.PI) / 180; // 5 degrees in radians
-    mirror.orientation = newOrientation;
+    parabolicMirror.orientation = newOrientation;
 
     recalculateRays();
   } else if (event.code === "ArrowRight") {
     // Rotate mirror clockwise by 5 degrees
-    const mirror = mirrors[1] as ParabolicMirror;
-    const currentOrientation = mirror.orientation;
+    
+    const currentOrientation = parabolicMirror.orientation;
     const newOrientation = currentOrientation + (5 * Math.PI) / 180; // 5 degrees in radians
-    mirror.orientation = newOrientation;
+    parabolicMirror.orientation = newOrientation;
 
     recalculateRays();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,21 +59,32 @@ const mirrors: Mirror[] = [
 function recalculateRays() {
   rays = [...emitter.generateRays()];
 
-  let anyBounced = true;
-  for (let i = 0; i < 10 && anyBounced; i++) {
-    anyBounced = false;
-    for (const mirror of mirrors) {
-      rays = rays.flatMap((ray) => {
-        const newRaysFromThisMirror = mirror.splitAndReflectSegment(ray);
-        if (newRaysFromThisMirror.length > 0) {
-          anyBounced = true;
-          return newRaysFromThisMirror;
-        } else {
-          return [ray];
-        }
-      });
-    }
-  }
+	let anyBounced = true;
+	for (let i = 0; i < 10 && anyBounced; i++) {
+		anyBounced = false;
+		const nextRays: Ray[] = [];
+		for (const ray of rays) {
+			let closestMirror: Mirror | null = null;
+			let closestDistance = Infinity;
+			for (const mirror of mirrors) {
+				const d = mirror.distanceToIntersection(ray);
+				if (d < closestDistance) {
+					closestDistance = d;
+					closestMirror = mirror;
+				}
+			}
+			if (closestMirror && Number.isFinite(closestDistance)) {
+				const split = closestMirror.splitAndReflectSegment(ray);
+				if (split.length > 0) {
+					nextRays.push(...split);
+					anyBounced = true;
+					continue;
+				}
+			}
+			nextRays.push(ray);
+		}
+		rays = nextRays;
+	}
 }
 
 // Create grid with default options (100px major spacing, 2 minor divisions = 50px minor spacing)

--- a/src/raytracing/FlatMirror.ts
+++ b/src/raytracing/FlatMirror.ts
@@ -86,7 +86,7 @@ export class FlatMirror extends Mirror {
       beforeDirection,
       beforeLength,
       { start: timeRange.start, end: timeRange.start + t * (timeRange.end - timeRange.start) },
-      "red", // color
+      ray.color,
       spawnedByObjectID,
       this.id,
     );
@@ -110,7 +110,7 @@ export class FlatMirror extends Mirror {
       afterDirection,
       afterLength,
       { start: timeRange.start + t * (timeRange.end - timeRange.start), end: timeRange.end },
-      "red", // color
+      ray.color,
       this.id,
     );
 

--- a/src/raytracing/FlatMirror.ts
+++ b/src/raytracing/FlatMirror.ts
@@ -117,6 +117,48 @@ export class FlatMirror extends Mirror {
     return [before, after];
   }
 
+  public distanceToIntersection(ray: Ray): number {
+    const { origin, direction, length, spawnedByObjectID, hitObjectID } = ray;
+    if (this.id === hitObjectID || this.id === spawnedByObjectID) {
+      return Infinity;
+    }
+
+    const x1 = origin.x;
+    const y1 = origin.y;
+    const x2 = origin.x + Math.cos(direction) * length;
+    const y2 = origin.y + Math.sin(direction) * length;
+
+    const M = this.position;
+    const D = { dx: -this.normal.dy, dy: this.normal.dx };
+
+    const segDx = x2 - x1;
+    const segDy = y2 - y1;
+    const det = segDx * D.dy - segDy * D.dx;
+    if (Math.abs(det) < 1e-8) {
+      return Infinity;
+    }
+
+    const t = ((M.x - x1) * D.dy - (M.y - y1) * D.dx) / det;
+    if (t < 0 || t > 1) {
+      return Infinity;
+    }
+
+    const ix = x1 + t * segDx;
+    const iy = y1 + t * segDy;
+
+    const mirrorDirLen = Math.hypot(D.dx, D.dy);
+    const dirX = D.dx / mirrorDirLen;
+    const dirY = D.dy / mirrorDirLen;
+    const vix = ix - M.x;
+    const viy = iy - M.y;
+    const proj = vix * dirX + viy * dirY;
+    if (proj < -this.length / 2 || proj > this.length / 2) {
+      return Infinity;
+    }
+
+    return t * length;
+  }
+
   render(context: CanvasRenderingContext2D) {
     // Perpendicular direction to normal
     const perpDx = -this.normal.dy;

--- a/src/raytracing/Mirror.ts
+++ b/src/raytracing/Mirror.ts
@@ -13,5 +13,10 @@ export abstract class Mirror {
    * If no intersection, it returns an empty array
    */
   abstract splitAndReflectSegment(ray: Ray): Ray[];
+  /**
+   * Returns the distance from the ray origin to the intersection point with this mirror,
+   * or Infinity if there is no intersection.
+   */
+  abstract distanceToIntersection(ray: Ray): number;
   abstract render(context: CanvasRenderingContext2D): void;
 }

--- a/src/raytracing/ParabolicMirror.ts
+++ b/src/raytracing/ParabolicMirror.ts
@@ -311,6 +311,19 @@ export class ParabolicMirror extends Mirror {
     return [before, after];
   }
 
+  public distanceToIntersection(ray: Ray): number {
+    const { spawnedByObjectID, hitObjectID, length } = ray;
+    if (this.id === hitObjectID || this.id === spawnedByObjectID) {
+      return Infinity;
+    }
+
+    const intersection = this.findIntersection(ray);
+    if (!intersection) {
+      return Infinity;
+    }
+    return intersection.tFraction * length;
+  }
+
   render(context: CanvasRenderingContext2D) {
     context.strokeStyle = "darkgreen";
     context.lineWidth = 2;

--- a/src/raytracing/ParabolicMirror.ts
+++ b/src/raytracing/ParabolicMirror.ts
@@ -255,6 +255,7 @@ export class ParabolicMirror extends Mirror {
       return [ray]; // No intersection
     }
 
+    debugger;
     const { x: ix, y: iy, tFraction } = intersection;
 
     // Create ray segment before intersection


### PR DESCRIPTION
Add `distanceToIntersection` method to `Mirror` and its subclasses to return the distance from a ray's origin to its intersection point, or `Infinity`.

---
<a href="https://cursor.com/background-agent?bcId=bc-254f49ef-6a91-4b3c-a014-3c32cd5cc5f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-254f49ef-6a91-4b3c-a014-3c32cd5cc5f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

