### PR TITLE
Make mirror non-reflective from behind

### DIFF
--- a/src/raytracing/FlatMirror.ts
+++ b/src/raytracing/FlatMirror.ts
@@ -100,6 +100,10 @@ export class FlatMirror extends Mirror {
     const ny = this.normal.dy / nLen;
     // Reflect: R = I - 2*(I·N)*N
     const dot = incident.dx * nx + incident.dy * ny;
+    // If the incident direction is aligned with the normal (back face), do not reflect
+    if (dot >= 0) {
+      return [before];
+    }
     const rx = incident.dx - 2 * dot * nx;
     const ry = incident.dy - 2 * dot * ny;
 

--- a/src/raytracing/ParabolicMirror.ts
+++ b/src/raytracing/ParabolicMirror.ts
@@ -286,6 +286,10 @@ export class ParabolicMirror extends Mirror {
 
     // Reflect in local coordinates: R = I - 2*(I·N)*N
     const dot = localIncident.dx * localNormal.dx + localIncident.dy * localNormal.dy;
+    // If the incident direction is aligned with the normal (back face), do not reflect
+    if (dot >= 0) {
+      return [before];
+    }
     const localReflected = {
       dx: localIncident.dx - 2 * dot * localNormal.dx,
       dy: localIncident.dy - 2 * dot * localNormal.dy,


### PR DESCRIPTION
Make the back of mirrors non-reflective by skipping ray generation when the incident ray aligns with the surface normal.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab8f3615-8ec1-4d47-b187-83e6b3666793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab8f3615-8ec1-4d47-b187-83e6b3666793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

